### PR TITLE
Minor changes to resolve linter warnings

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -3,12 +3,13 @@
 """ Basic Classes Portfolio, Item, HistoryPoint and methods"""
 
 import uuid
-import matplotlib.pyplot as plt
+import logging
+import bisect
 from datetime import date
 from forex_python.bitcoin import BtcConverter
 from forex_python.converter import CurrencyRates
-import logging
-import bisect
+
+import matplotlib.pyplot as plt
 
 # cfr. Classes https://docs.python.org/3/tutorial/classes.html
 # cfr. logging https://docs.python.org/3/howto/logging.html
@@ -84,11 +85,11 @@ def get_exchange_rate(given_date: date, from_currency: str, to_currency: str):
     return rate
 
 
-def plot_piechart(dict):
+def plot_piechart(piechart_dict):
     """ Plot piechart with the slices ordered counter-clockwise. """
 
-    labels = dict.keys()
-    sizes = dict.values()
+    labels = piechart_dict.keys()
+    sizes = piechart_dict.values()
     fig1, ax1 = plt.subplots()
     ax1.pie(sizes, labels=labels, autopct='%1.1f%%',
             shadow=False, startangle=90)
@@ -143,7 +144,7 @@ class Portfolio:
 
         portfolio_balance = 0
         for item in self.item_list:
-            (closest_date, closest_balance) = item.get_item_balance(
+            closest_balance, _ = item.get_item_balance(
                 self.currency, given_date)
             # would be good to return closest_date to give transparency
             portfolio_balance += closest_balance
@@ -155,7 +156,7 @@ class Portfolio:
 
         piechart = {'portfolio_balance': 0}
         for item in self.item_list:
-            (closest_date, closest_balance) = item.get_item_balance(
+            closest_balance, _ = item.get_item_balance(
                 self.currency, given_date)
             # would be good to return closest_date to give transparency
             piechart['portfolio_balance'] += closest_balance
@@ -251,15 +252,16 @@ class Item:
             closest_balance = closest_match[1] * exchange_rate
         else:  # empty list
             logging.warning(
-                "get_item_balance() returns 0 for Item with empty History: %s ('%s')",
+                "get_item_balance() returns 0 for Item"
+                " with empty History: %s ('%s')",
                 str(self.unique_id), self.name)
             closest_date = given_date
             closest_balance = 0
 
-        return (closest_date, closest_balance)
+        return closest_balance, closest_date
 
     def display(self):
-        """ Display Item(text)"""
+        """ Display Item (text)"""
 
         msgs = []
         msgs.append('\n  ITEM')
@@ -391,13 +393,6 @@ def main():
 
     logging.info('Success')
     logging.info('\n--------RUN ENDS--------\n')
-
-    """
-    # this should fail
-    crypto1 = Item(category='asset', subcategory='stock', currency='USD',
-                   name='Amazon', description='Amazon stock in Revolut',
-                   portfolio=None)
-    """
 
 
 if __name__ == "__main__":

--- a/tests/test_exchange.py
+++ b/tests/test_exchange.py
@@ -5,56 +5,67 @@
 """ test get_exchange_rate"""
 
 import unittest
-import logging
 
-from src.utils import get_exchange_rate
 from datetime import date, timedelta
 
 from forex_python.converter import CurrencyRates
 from forex_python.bitcoin import BtcConverter
 
+from src.utils import get_exchange_rate
 
-class Test_get_exchange_rate(unittest.TestCase):
+
+class TestExchangeRates(unittest.TestCase):
+
+    """ Class to test interface with exchange rate service """
 
     def setUp(self):
 
-        c = CurrencyRates()
-        b = BtcConverter()
-        BTC_EUR = b.get_latest_price('EUR')
-        USD_BTC = 1 / b.get_latest_price('USD')
-        USD_EUR = c.get_rate('USD', 'EUR')
+        btc_handler = BtcConverter()
+        btc_eur = btc_handler.get_latest_price('EUR')
+        usd_btc = 1 / btc_handler.get_latest_price('USD')
+
+        currency_handler = CurrencyRates()
+        usd_eur = currency_handler.get_rate('USD', 'EUR')
+
+        date_26_8 = date(2021, 8, 26)
+        date_today = date.today()
+        date_future = date.today()+timedelta(days=2)
+        date_holiday1 = date(2021, 8, 28)
+        date_holiday2 = date(2021, 8, 29)
 
         self.my_test_points = [
-            (date(2021, 8, 26), 'BTC', 'BTC', 'supported', 1),  # past BTC ab
-            (date(2021, 8, 26), 'BTC', 'EUR', 'supported', 39848.2899),  # past BTC a
-            (date(2021, 8, 26), 'USD', 'BTC', 'supported', 2.134799265262721e-05),  # past BTC b
-            (date(2021, 8, 26), 'USD', 'EUR', 'supported', 0.8498342823149485),  # past forex ab
-            (date(2021, 8, 26), 'EUR', 'USD', 'supported', 1.1767),  # past forex ab
-            (date(2021, 8, 26), 'ETH', 'USD', 'unsupported', None),  # past unsup a
-            (date(2021, 8, 26), 'EUR', 'AAA', 'unsupported', None),  # past unsup b
-            (date(2021, 8, 26), 'BTC', 'AAA', 'unsupported', None),  # past BTC a unsup b
-            (date(2021, 8, 26), 'BBB', 'CCC', 'unsupported', None),  # past unsup ab
-            (date.today(), 'BTC', 'EUR', 'supported', BTC_EUR),  # today BTC a
-            (date.today(), 'USD', 'BTC', 'supported', USD_BTC),  # today BTC b
-            (date.today(), 'USD', 'EUR', 'supported', USD_EUR),  # today forex ab
-            (date.today(), 'ETH', 'USD', 'unsupported', None),  # today unsup a
-            (date.today(), 'EUR', 'AAA', 'unsupported', None),  # today unsup b
-            (date.today(), 'BBB', 'CCC', 'unsupported', None),  # today unsup ab
-            (date.today(), 'BTC', 'AAA', 'unsupported', None),  # today BTC a unsup b
-            (date.today()+timedelta(days=2), 'BTC', 'BTC', 'supported', None),  # future BTC ab
-            (date.today()+timedelta(days=2), 'BTC', 'EUR', 'supported', None),  # future BTC a
-            (date.today()+timedelta(days=2), 'USD', 'BTC', 'supported', None),  # future BTC b
-            (date.today()+timedelta(days=2), 'USD', 'EUR', 'supported', None),  # future forex ab
-            (date.today()+timedelta(days=2), 'EUR', 'USD', 'supported', None),  # future forex ab
-            (date.today()+timedelta(days=2), 'ETH', 'USD', 'unsupported', None),  # future unsup a
-            (date.today()+timedelta(days=2), 'EUR', 'AAA', 'unsupported', None),  # future unsup b
-            (date.today()+timedelta(days=2), 'BTC', 'AAA', 'unsupported', None),  # future BTC a unsup b
-            (date.today()+timedelta(days=2), 'BBB', 'CCC', 'unsupported', None),  # future unsup ab
-            (date(2021, 8, 28), 'USD', 'EUR', 'holiday', None),  # future BTC ab
-            (date(2021, 8, 29), 'BTC', 'EUR', 'holiday', None),  # future BTC a
+            (date_26_8, 'BTC', 'BTC', 'supported', 1),  # past BTC ab
+            (date_26_8, 'BTC', 'EUR', 'supported', 39848.2899),  # past BTC a
+            (date_26_8, 'USD', 'BTC', 'supported', 2.1347992e-05),  # past BTC b
+            (date_26_8, 'USD', 'EUR', 'supported', 0.84983428),  # past forex ab
+            (date_26_8, 'EUR', 'USD', 'supported', 1.1767),  # past forex ab
+            (date_26_8, 'ETH', 'USD', 'unsupported', None),  # past unsup a
+            (date_26_8, 'EUR', 'AAA', 'unsupported', None),  # past unsup b
+            (date_26_8, 'BTC', 'AAA', 'unsupported', None),  # past BTC + unsup
+            (date_26_8, 'BBB', 'CCC', 'unsupported', None),  # past unsup ab
+            (date_today, 'BTC', 'EUR', 'supported', btc_eur),  # today BTC a
+            (date_today, 'USD', 'BTC', 'supported', usd_btc),  # today BTC b
+            (date_today, 'USD', 'EUR', 'supported', usd_eur),  # today forex ab
+            (date_today, 'ETH', 'USD', 'unsupported', None),  # today unsup a
+            (date_today, 'EUR', 'AAA', 'unsupported', None),  # today unsup b
+            (date_today, 'BBB', 'CCC', 'unsupported', None),  # today unsup ab
+            (date_today, 'BTC', 'AAA', 'unsupported', None),  # today BTC + unsup
+            (date_future, 'BTC', 'BTC', 'supported', None),  # future BTC ab
+            (date_future, 'BTC', 'EUR', 'supported', None),  # future BTC a
+            (date_future, 'USD', 'BTC', 'supported', None),  # future BTC b
+            (date_future, 'USD', 'EUR', 'supported', None),  # future forex ab
+            (date_future, 'EUR', 'USD', 'supported', None),  # future forex ab
+            (date_future, 'ETH', 'USD', 'unsupported', None),  # future unsup a
+            (date_future, 'EUR', 'AAA', 'unsupported', None),  # future unsup b
+            (date_future, 'BTC', 'AAA', 'unsupported', None),  # fut BTC a unsup b
+            (date_future, 'BBB', 'CCC', 'unsupported', None),  # fut unsup ab
+            (date_holiday1, 'USD', 'EUR', 'holiday', None),  # future BTC ab
+            (date_holiday2, 'BTC', 'EUR', 'holiday', None),  # future BTC a
         ]
 
     def test_1_valid_cases(self):
+        """ Retrieving valid past exchange rates from service """
+
         msg = ""
         for point in self.my_test_points:
             given_date = point[0]
@@ -64,11 +75,14 @@ class Test_get_exchange_rate(unittest.TestCase):
                 to_curr = point[2]
                 result = get_exchange_rate(given_date, from_curr, to_curr)
                 check = point[4]
-                msg += f"\nExchange rate {from_curr}/{to_curr} on {given_date.isoformat()}={str(result)} vs. {str(check)}"
+                msg += f"\nExchange rate {from_curr}/{to_curr} on"\
+                    "{given_date.isoformat()}={str(result)} vs. {str(check)}"
                 self.assertAlmostEqual(result, check, places=4)
         # print(msg)
 
     def test_2_today_rates(self):
+        """ Retrieving current exchange rates from service """
+
         msg = ""
         for point in self.my_test_points:
             given_date = point[0]
@@ -78,13 +92,17 @@ class Test_get_exchange_rate(unittest.TestCase):
                 to_curr = point[2]
                 result = get_exchange_rate(given_date, from_curr, to_curr)
                 check = point[4]
-                msg += f"\nExchange rate {from_curr}/{to_curr} on {given_date.isoformat()}={str(result)}"
-        # print(msg)
+                msg += f"\nExchange rate {from_curr}/{to_curr} "\
+                    "on {given_date.isoformat()}={str(result)}"
+                self.assertAlmostEqual(result, check, msg=f"Failed at sample: {point}", places=4)
+        # print(msg) --> replace with logging
 
     def test_3_future_dates(self):
+        """ Retrieving future exchange rates from service """
+
         for point in self.my_test_points:
             given_date = point[0]
-            case = point[3]
+            # not used: case = point[3]
             if given_date > date.today():
                 from_curr = point[1]
                 to_curr = point[2]
@@ -92,6 +110,8 @@ class Test_get_exchange_rate(unittest.TestCase):
                 self.assertIsNone(result, "Future rates should return None")
 
     def test_4_unsupported_cases(self):
+        """ Retrieving unsupported exchange rates from service """
+
         for point in self.my_test_points:
             given_date = point[0]
             case = point[3]
@@ -102,6 +122,8 @@ class Test_get_exchange_rate(unittest.TestCase):
                 self.assertIsNone(result, "Unsupported rates should return None")
 
     def test_5_holiday(self):
+        """ Retrieving from service exchange rates on a holiday"""
+
         for point in self.my_test_points:
             given_date = point[0]
             case = point[3]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,10 +8,12 @@ import unittest
 import logging
 
 from datetime import date
-from src.utils import Portfolio, plot_piechart
+from src.utils import Portfolio
 
 
 class TestPortfolio(unittest.TestCase):
+
+    """ Class to test basic Portfolio methods """
 
     def setUp(self):
         """ Create a fixture of a basic portfolio with some items """
@@ -57,7 +59,7 @@ class TestPortfolio(unittest.TestCase):
                 'name': 'Fondo NARANJA 50/40',
                 'description': 'Investment fund in ING Direct'
             },
-            {        # plot_piechart(piechart)
+            {
                 'category': 'asset',
                 'subcategory': 'stock',
                 'currency': 'USD',
@@ -133,9 +135,13 @@ class TestPortfolio(unittest.TestCase):
         self.my_portfolio = my_portfolio
 
     def test_create(self):
+        """ Test 4 items created inside the Portfolio"""
+
         self.assertEqual(len(self.my_portfolio.item_list), 4)
 
     def test_balance(self):
+        """ Test that Portfolio balance is well computed"""
+
         for i in [14]:  # , 17, 19, 21]:
             dat = date(2021, 8, i)
             balance = self.my_portfolio.get_portfolio_balance(given_date=dat)
@@ -144,25 +150,14 @@ class TestPortfolio(unittest.TestCase):
             self.assertAlmostEqual(balance, 163860.222, places=4)
 
     def test_piechart(self):
+        """ Test that Portfolio piechart is well computed"""
+
         for i in [14]:  # , 17, 19, 21]:
             dat = date(2021, 8, i)
             piechart = self.my_portfolio.get_portfolio_piechart(given_date=dat)
             logging.info("Piechart of 'my_portfolio' in %s on %s:\n %s",
                          self.my_portfolio.currency, dat.isoformat(), str(piechart))
             self.assertAlmostEqual(piechart['fund'], 65.8878, places=4)
-            # plot_piechart(piechart)
 
     def tearDown(self):
         pass
-
-
-"""
-def main():
-
-if __name__ == "__main__":
-    # test.py ran directly
-    main()
-else:
-    # test.py was imported
-    pass
-"""


### PR DESCRIPTION
Renaming of functions and variables, adding docstrings, splitting long
 lines etc in `test_utils.py`, `test_exchange.py` and `utils.py`.

* Change order of parameters returned by get_item_balance to allow for
  calls that only use closest_balance and not closest_date, i.e.:

   `closest_balance, closest_date = get_item_balance(...)`
   `closest_balance, _ =  get_item_balance(...)`